### PR TITLE
Use Dalli for memcache store

### DIFF
--- a/lib/open_id_authentication/middleware.rb
+++ b/lib/open_id_authentication/middleware.rb
@@ -28,9 +28,9 @@ module OpenIdAuthentication
         require 'openid/store/filesystem'
         OpenID::Store::Filesystem.new(Rails.root.join('tmp/openids'))
       when :memcache
-        require 'memcache'
+        require 'dalli'
         require 'openid/store/memcache'
-        OpenID::Store::Memcache.new(MemCache.new(args))
+        OpenID::Store::Memcache.new(Dalli::Client.new(args))
       else
         store
       end


### PR DESCRIPTION
memcache-client has been deprecated since 2010 and ruby-openid has
supported Dalli as a memcache client since november 2010.